### PR TITLE
Development

### DIFF
--- a/StudentManagementSystem.Core/Services/Admin/AdminStudentService.cs
+++ b/StudentManagementSystem.Core/Services/Admin/AdminStudentService.cs
@@ -443,7 +443,7 @@ namespace StudentManagementSystem.Core.Services.Admin
             if (remark == null)
             {
                 logger.LogWarning($"Attempted to edit a non-existing remark with ID: {remarkId} .");
-                throw new ArgumentException($"Remark with ID: {remarkId} not found.");
+                throw new KeyNotFoundException($"Remark with ID: {remarkId} not found.");
             }
 
             remark.RemarkText = model.RemarkText;
@@ -469,7 +469,7 @@ namespace StudentManagementSystem.Core.Services.Admin
 
             if (remark == null)
             {
-                throw new ArgumentException($"Remark with ID: {id} not found.");
+                throw new KeyNotFoundException($"Remark with ID: {id} not found.");
             }
 
             return remark;

--- a/StudentManagementSystem.Core/Services/TeacherService.cs
+++ b/StudentManagementSystem.Core/Services/TeacherService.cs
@@ -271,7 +271,7 @@ namespace StudentManagementSystem.Core.Services
             {
                 StudentId = studentId,
                 CourseId = model.CourseId,
-                Date = DateTime.SpecifyKind(model.AbsenceDate.Date, DateTimeKind.Utc)
+                Date = DateTime.SpecifyKind(model.AbsenceDate, DateTimeKind.Utc)
             };
 
             student.Аbsences.Add(absence);
@@ -410,7 +410,6 @@ namespace StudentManagementSystem.Core.Services
                     StudentId = g.StudentId,
                     CourseId = g.CourseId,
                     GradeScore = g.GradeScore,
-
                     GradeType = g.GradeType,
                     SelectedCourseId = g.CourseId,
                     SelectedGrade = g.GradeScore.ToString(),
@@ -483,14 +482,14 @@ namespace StudentManagementSystem.Core.Services
 
         public async Task<AbsenceFormViewModel> GetAbsenceByIdAsync(int absenceId)
         {
-            var absence =await repository.All<Absence>()
+            var absence =await repository.AllAsReadOnly<Absence>()
                 .Where(a => a.Id == absenceId && !a.IsDeleted)
                 .Select(a=> new AbsenceFormViewModel
                 {
                     Id = absenceId,
                     StudentId = a.StudentId,
                     CourseId = a.CourseId,
-                    AbsenceDate = a.Date.Date
+                    AbsenceDate = a.Date
                 })
                 .FirstOrDefaultAsync();
 
@@ -514,7 +513,7 @@ namespace StudentManagementSystem.Core.Services
             }
 
             // Ensure DateTime written to Postgres has Kind=Utc
-            absence.Date = DateTime.SpecifyKind(model.AbsenceDate.Date, DateTimeKind.Utc);
+            absence.Date = DateTime.SpecifyKind(model.AbsenceDate, DateTimeKind.Utc);
             absence.CourseId = model.CourseId;
 
             await repository.SaveChangesAsync();

--- a/StudentServiceTests/Admin/AdminClassServiceTests.cs
+++ b/StudentServiceTests/Admin/AdminClassServiceTests.cs
@@ -90,6 +90,8 @@ namespace Tests.Admin
 
             mockRepository.Setup(r => r.AddAsync(It.IsAny<Class>())).Returns(Task.CompletedTask);
 
+            var emptyClasses = new List<Class>().AsQueryable().BuildMock();
+            mockRepository.Setup(r => r.AllAsReadOnly<Class>()).Returns(emptyClasses);
 
             var result = await adminClassService.CreateClassAsync(model);
 

--- a/StudentServiceTests/Admin/AdminCourseServiceTests.cs
+++ b/StudentServiceTests/Admin/AdminCourseServiceTests.cs
@@ -1,7 +1,8 @@
-﻿using MockQueryable;
+﻿using Microsoft.Extensions.Logging;
+using MockQueryable;
 using Moq;
-using Microsoft.Extensions.Logging;
 using StudentManagementSystem.Core.Models.Admin.Course;
+using StudentManagementSystem.Core.Services;
 using StudentManagementSystem.Core.Services.Admin;
 using StudentManagementSystem.Infrastructure.Data.Common;
 using StudentManagementSystem.Infrastructure.Data.Models;
@@ -82,19 +83,15 @@ namespace Tests.Admin
         }
 
         [Test]
-        public async Task CourseExistAsync_ShouldReturnFalse_WhenCourseDoesNotExist()
+        public void CourseExistAsync_ShouldThrowKeyNotFoundException_WhenCourseDoesNotExist()
         {
-            
             mockRepository.Setup(repo => repo.AllAsReadOnly<Course>()).Returns(new List<Course>
             {
                 new Course { Id = 1, Name = "Math 101", IsDeleted = false }
             }.AsQueryable().BuildMock());
 
-            
-            var result = await courseService.CourseExistAsync(99);
-
-            
-            Assert.IsFalse(result);
+            var ex = Assert.ThrowsAsync<KeyNotFoundException>(async () => await courseService.CourseExistAsync(99));
+            Assert.That(ex.Message, Is.EqualTo("Course with ID: 99 not found"));
         }
 
         [Test]
@@ -114,10 +111,10 @@ namespace Tests.Admin
             mockRepository.Setup(repo => repo.AddAsync(It.IsAny<Course>())).Callback<Course>(c => c.Id = newCourseId).Returns(Task.CompletedTask);
             mockRepository.Setup(repo => repo.SaveChangesAsync()).ReturnsAsync(1);
 
+            mockRepository.Setup(repo => repo.AllAsReadOnly<Course>()).Returns(new List<Course>().AsQueryable().BuildMock());
             
             var result = await courseService.CreateCourseAsync(courseForm, publisherId);
 
-            
             Assert.That(result, Is.EqualTo(newCourseId));
             mockRepository.Verify(repo => repo.AddAsync(It.Is<Course>(c =>
                 c.Name == courseForm.Name &&
@@ -168,19 +165,19 @@ namespace Tests.Admin
         }
 
         [Test]
-        public async Task GetCourseDetailsModelByIdAsync_ShouldThrowArgumentException_WhenCourseDoesNotExist()
+        public void GetCourseDetailsModelByIdAsync_ShouldThrowKeyNotFoundException_WhenCourseDoesNotExist()
         {
             
             mockRepository.Setup(repo => repo.AllAsReadOnly<Course>())
                 .Returns(new List<Course>().AsQueryable().BuildMock());
 
              
-            var exception = Assert.ThrowsAsync<ArgumentException>(() => courseService.GetCourseDetailsModelByIdAsync(99));
+            var exception = Assert.ThrowsAsync<KeyNotFoundException>(() => courseService.GetCourseDetailsModelByIdAsync(99));
             Assert.That(exception.Message, Is.EqualTo("Course with ID 99 not found."));
         }
 
         [Test]
-        public async Task GetCourseDetailsModelByIdAsync_ShouldThrowArgumentException_WhenCourseIsDeleted()
+        public void GetCourseDetailsModelByIdAsync_ShouldThrowKeyNotFoundException_WhenCourseIsDeleted()
         {
             
             var course = new Course
@@ -201,32 +198,15 @@ namespace Tests.Admin
                 .Returns(new List<Course> { course }.AsQueryable().BuildMock());
 
              
-            var exception = Assert.ThrowsAsync<ArgumentException>(() => courseService.GetCourseDetailsModelByIdAsync(1));
+            var exception = Assert.ThrowsAsync<KeyNotFoundException>(() => courseService.GetCourseDetailsModelByIdAsync(1));
             Assert.That(exception.Message, Is.EqualTo("Course with ID 1 not found."));
         }
-
 
         [Test]
         public async Task DeleteCourseAsync_ShouldSetCourseToDeleted_WhenCourseExistsAndNotDeleted()
         {
             
             var course = new Course { Id = 1, Name = "Math 101", IsDeleted = false };
-            mockRepository.Setup(repo => repo.GetByIdAsync<Course>(1)).ReturnsAsync(course);
-            mockRepository.Setup(repo => repo.SaveChangesAsync()).ReturnsAsync(1);
-
-            
-            await courseService.DeleteCourseAsync(1);
-
-            
-            Assert.IsTrue(course.IsDeleted);
-            mockRepository.Verify(repo => repo.SaveChangesAsync(), Times.Once);
-        }
-
-        [Test]
-        public async Task DeleteCourseAsync_ShouldNotChangeCourse_WhenCourseAlreadyDeleted()
-        {
-            
-            var course = new Course { Id = 1, Name = "Math 101", IsDeleted = true };
             mockRepository.Setup(repo => repo.GetByIdAsync<Course>(1)).ReturnsAsync(course);
             mockRepository.Setup(repo => repo.SaveChangesAsync()).ReturnsAsync(1);
 
@@ -266,7 +246,7 @@ namespace Tests.Admin
         }
 
         [Test]
-        public async Task EditCourseAsync_ShouldNotUpdateCourse_WhenCourseIsDeleted()
+        public void EditCourseAsync_ShouldThrowKeyNotFoundException_WhenCourseIsDeleted()
         {
             
             var course = new Course { Id = 1, Name = "Math 101", Description = "Old Description", IsDeleted = true };
@@ -282,12 +262,8 @@ namespace Tests.Admin
             mockRepository.Setup(repo => repo.SaveChangesAsync()).ReturnsAsync(1);
 
             
-            await courseService.EditCourseAsync(1, model, publisherId);
-
-            
-            Assert.That(course.Name, Is.EqualTo("Math 101"));
-            Assert.That(course.Description, Is.EqualTo("Old Description"));
-            mockRepository.Verify(repo => repo.SaveChangesAsync(), Times.Once);
+            var ex = Assert.ThrowsAsync<KeyNotFoundException>(async () => await courseService.EditCourseAsync(1, model, publisherId));
+            Assert.That(ex.Message, Is.EqualTo("Course with ID 1 not found."));
         }
 
         [Test]
@@ -350,13 +326,13 @@ namespace Tests.Admin
         }
 
         [Test]
-        public async Task GetCourseByIdAsync_ShouldThrowException_WhenCourseDoesNotExist()
+        public void GetCourseByIdAsync_ShouldThrowKeyNotFoundException_WhenCourseDoesNotExist()
         {
             
             mockRepository.Setup(repo => repo.GetByIdAsync<CourseServiceModel>(99)).ReturnsAsync((CourseServiceModel)null);
 
              
-            var exception = Assert.ThrowsAsync<ArgumentException>(() => courseService.GetCourseByIdAsync(99));
+            var exception = Assert.ThrowsAsync<KeyNotFoundException>(() => courseService.GetCourseByIdAsync(99));
             Assert.That(exception.Message, Is.EqualTo("Course with ID 99 not found."));
         }
 
@@ -394,19 +370,19 @@ namespace Tests.Admin
         }
 
         [Test]
-        public async Task GetCourseFormModelByIdAsync_ShouldThrowArgumentException_WhenCourseDoesNotExist()
+        public void GetCourseFormModelByIdAsync_ShouldThrowKeyNotFoundException_WhenCourseDoesNotExist()
         {
             
             mockRepository.Setup(repo => repo.AllAsReadOnly<Course>())
                 .Returns(new List<Course>().AsQueryable().BuildMock());
 
              
-            var exception = Assert.ThrowsAsync<ArgumentException>(() => courseService.GetCourseFormModelByIdAsync(99));
+            var exception = Assert.ThrowsAsync<KeyNotFoundException>(() => courseService.GetCourseFormModelByIdAsync(99));
             Assert.AreEqual("Course with ID 99 not found.", exception.Message);
         }
 
         [Test]
-        public async Task GetCourseFormModelByIdAsync_ShouldThrowArgumentException_WhenCourseIsDeleted()
+        public void GetCourseFormModelByIdAsync_ShouldThrowKeyNotFoundException_WhenCourseIsDeleted()
         {
             
             var course = new Course
@@ -422,7 +398,7 @@ namespace Tests.Admin
                 .Returns(new List<Course> { course }.AsQueryable().BuildMock());
 
              
-            var exception = Assert.ThrowsAsync<ArgumentException>(() => courseService.GetCourseFormModelByIdAsync(1));
+            var exception = Assert.ThrowsAsync<KeyNotFoundException>(() => courseService.GetCourseFormModelByIdAsync(1));
             Assert.That(exception.Message, Is.EqualTo("Course with ID 1 not found."));
         }
 

--- a/StudentServiceTests/Admin/AdminScheduleServiceTests.cs
+++ b/StudentServiceTests/Admin/AdminScheduleServiceTests.cs
@@ -104,6 +104,10 @@ namespace Tests.Admin
             mockRepository.Setup(repo => repo.AddAsync(It.IsAny<CourseSchedule>())).Returns(Task.CompletedTask);
             mockRepository.Setup(repo => repo.SaveChangesAsync()).ReturnsAsync(1);
 
+            // Ensure AllAsReadOnly returns an IQueryable with an async provider for EF Core async extensions
+            mockRepository.Setup(repo => repo.AllAsReadOnly<CourseSchedule>())
+                .Returns(Enumerable.Empty<CourseSchedule>().AsQueryable().BuildMock());
+
             
             await adminScheduleService.AddCourseScheduleAsync(model);
 
@@ -139,20 +143,6 @@ namespace Tests.Admin
             mockRepository.Verify(repo => repo.SaveChangesAsync(), Times.Once);
         }
 
-        [Test]
-        public async Task DeleteCourseScheduleAsync_ShouldDoNothing_WhenScheduleDoesNotExist()
-        {
-            
-            mockRepository.Setup(repo => repo.GetByIdAsync<CourseSchedule>(1))
-                .ReturnsAsync((CourseSchedule)null);
-
-            
-            await adminScheduleService.DeleteCourseScheduleAsync(1);
-
-            
-            mockRepository.Verify(repo => repo.DeleteSchedule(It.IsAny<CourseSchedule>()), Times.Never);
-            mockRepository.Verify(repo => repo.SaveChangesAsync(), Times.Never);
-        }
         [Test]
         public async Task EditCourseScheduleAsync_ShouldUpdateSchedule_WhenValidModelProvided()
         {
@@ -235,12 +225,11 @@ namespace Tests.Admin
         [Test]
         public async Task GetCourseScheduleByIdAsync_ShouldThrowException_WhenScheduleDoesNotExist()
         {
-            
             mockRepository.Setup(repo => repo.AllAsReadOnly<CourseSchedule>())
                 .Returns(Enumerable.Empty<CourseSchedule>().AsQueryable().BuildMock());
 
-            var exception = Assert.ThrowsAsync<Exception>(() => adminScheduleService.GetCourseScheduleByIdAsync(99));
-            Assert.That(exception.Message, Is.EqualTo("Course schedule not found"));
+            var exception = Assert.ThrowsAsync<KeyNotFoundException>(() => adminScheduleService.GetCourseScheduleByIdAsync(99));
+            Assert.That(exception.Message, Is.EqualTo("Course schedule with ID: 99 not found."));
         }
 
     }

--- a/StudentServiceTests/Admin/AdminStudentServiceTests.cs
+++ b/StudentServiceTests/Admin/AdminStudentServiceTests.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging;
 using MockQueryable;
 using MockQueryable.Moq;
 using Moq;
+using NuGet.Protocol.Core.Types;
 using StudentManagementSystem.Core.Models.Admin.Student;
 using StudentManagementSystem.Core.Services.Admin;
 using StudentManagementSystem.Infrastructure.Data.Common;
@@ -181,8 +182,8 @@ namespace Tests.Admin
             repositoryMock.Setup(r => r.AllAsReadOnly<Student>()).Returns(Enumerable.Empty<Student>().AsQueryable().BuildMock());
 
             // Act & Assert
-            var ex = Assert.ThrowsAsync<ArgumentException>(async () => await adminStudentService.GetStudentByIdAsync(1));
-            Assert.That(ex.Message, Is.EqualTo("Student not found."));
+            var ex = Assert.ThrowsAsync<KeyNotFoundException>(async () => await adminStudentService.GetStudentByIdAsync(1));
+            Assert.That(ex.Message, Is.EqualTo("Student with ID: 1 not found."));
         }
 
         [Test]
@@ -203,7 +204,7 @@ namespace Tests.Admin
         }
 
         [Test]
-        public async Task ExistAsync_ShouldReturnFalse_WhenStudentDoesNotExist()
+        public async Task ExistAsync_ShouldReturnException_WhenNotFound()
         {
             // Arrange
             var studentId = 1;
@@ -211,29 +212,11 @@ namespace Tests.Admin
             repositoryMock.Setup(r => r.AllAsReadOnly<Student>())
                 .Returns(new List<Student>().AsQueryable().BuildMock());
 
-            // Act
-            var result = await adminStudentService.ExistAsync(studentId);
-
-            // Assert
-            Assert.That(result, Is.False);
+            // Assert & Act
+            var ex = Assert.ThrowsAsync<KeyNotFoundException>(() => adminStudentService.ExistAsync(studentId));
+            Assert.That(ex.Message, Is.EqualTo("Student with ID: 1 not found"));
         }
 
-        [Test]
-        public async Task ExistAsync_ShouldReturnFalse_WhenStudentIsDeleted()
-        {
-            // Arrange
-            var studentId = 1;
-            var student = new Student { Id = studentId, IsDeleted = true };
-
-            repositoryMock.Setup(r => r.AllAsReadOnly<Student>())
-                .Returns(new List<Student> { student }.AsQueryable().BuildMock());
-
-            // Act
-            var result = await adminStudentService.ExistAsync(studentId);
-
-            // Assert
-            Assert.That(result, Is.False);
-        }
         [Test]
         public async Task GetAllStudentsAsync_ShouldReturnAllStudents_WhenCalled()
         {
@@ -318,7 +301,7 @@ namespace Tests.Admin
         }
 
         [Test]
-        public async Task GetStudentDetailsModelByIdAsync_ShouldThrowArgumentException_WhenStudentDoesNotExist()
+        public async Task GetStudentDetailsModelByIdAsync_ShouldThrowKeyNotFoundException_WhenStudentDoesNotExist()
         {
             // Arrange
             var studentId = 1;
@@ -327,8 +310,8 @@ namespace Tests.Admin
                 .Returns(new List<Student>().AsQueryable().BuildMock());
 
             // Act & Assert
-            var ex = Assert.ThrowsAsync<ArgumentException>(() => adminStudentService.GetStudentDetailsModelByIdAsync(studentId));
-            Assert.That(ex.Message, Is.EqualTo("Student not found."));
+            var ex = Assert.ThrowsAsync<KeyNotFoundException>(() => adminStudentService.GetStudentDetailsModelByIdAsync(studentId));
+            Assert.That(ex.Message, Is.EqualTo("Student with ID: 1 not found."));
         }
 
         [Test]
@@ -365,7 +348,7 @@ namespace Tests.Admin
         }
 
         [Test]
-        public async  Task GetStudentFormModelByIdAsync_ShouldThrowArgumentException_WhenStudentDoesNotExist()
+        public async Task GetStudentFormModelByIdAsync_ShouldThrowException_WhenStudentDoesNotExist()
         {
             // Arrange
             var studentId = 1;
@@ -374,66 +357,8 @@ namespace Tests.Admin
                 .Returns(new List<Student>().AsQueryable().BuildMock());
 
             // Act & Assert
-            var ex = Assert.ThrowsAsync<ArgumentException>(() => adminStudentService.GetStudentFormModelByIdAsync(studentId));
-            Assert.That(ex.Message, Is.EqualTo("Student not found."));
-        }
-        [Test]
-        public async Task GetStudentGradesAsync_ShouldReturnStudentGrades()
-        {
-            // Arrange
-            var studentId = 1;
-            var grades = new List<Grade>
-            {
-                new Grade
-                {
-                    Id = 1,
-                    StudentId = studentId,
-                    GradeScore = 90,
-                    GradeAssignedDate = new DateTime(2023, 1, 1),
-                    GradeType = "Midterm",
-                    Course = new Course { Name = "Math" },
-                    Student = new Student { Class = new Class { Name = "A1" } },
-                    IsDeleted = false
-                },
-                new Grade
-                {
-                    Id = 2,
-                    StudentId = studentId,
-                    GradeScore = 85,
-                    GradeAssignedDate = new DateTime(2023, 2, 1),
-                    GradeType = "Final",
-                    Course = new Course { Name = "Science" },
-                    Student = new Student { Class = new Class { Name = "B1" } },
-                    IsDeleted = false
-                }
-            }.AsQueryable().BuildMock();
-
-            repositoryMock.Setup(r => r.AllAsReadOnly<Grade>()).Returns(grades);
-
-            // Act
-            var result = await adminStudentService.GetStudentGradesAsync(studentId);
-
-            // Assert
-            Assert.That(result, Is.Not.Null);
-            Assert.That(result.Count(), Is.EqualTo(2));
-            Assert.That(result.First().Name, Is.EqualTo("Science"));
-            Assert.That(result.Last().Name, Is.EqualTo("Math"));
-        }
-
-        [Test]
-        public async Task GetStudentGradesAsync_ShouldReturnEmpty_WhenNoGradesExist()
-        {
-            // Arrange
-            var studentId = 1;
-
-            repositoryMock.Setup(r => r.AllAsReadOnly<Grade>())
-                .Returns(new List<Grade>().AsQueryable().BuildMock());
-
-            // Act
-            var result = await adminStudentService.GetStudentGradesAsync(studentId);
-
-            // Assert
-            Assert.That(result, Is.Empty);
+            var ex = Assert.ThrowsAsync<KeyNotFoundException>(() => adminStudentService.GetStudentFormModelByIdAsync(studentId));
+            Assert.That(ex.Message, Is.EqualTo("Student with ID: 1 not found."));
         }
 
         [Test]
@@ -474,7 +399,7 @@ namespace Tests.Admin
         }
 
         [Test]
-        public async Task EditGradeAsync_ShouldThrowArgumentException_WhenGradeDoesNotExist()
+        public async Task EditGradeAsync_ShouldThrowKeyNotFoundException_WhenGradeDoesNotExist()
         {
             // Arrange
             var gradeId = 1;
@@ -489,8 +414,8 @@ namespace Tests.Admin
                 .Returns(new List<Grade>().AsQueryable().BuildMock());
 
             // Act & Assert
-            var ex = Assert.ThrowsAsync<ArgumentException>(() => adminStudentService.EditGradeAsync(gradeId, model));
-            Assert.That(ex.Message, Is.EqualTo("Grade not found."));
+            var ex = Assert.ThrowsAsync<KeyNotFoundException>(() => adminStudentService.EditGradeAsync(gradeId, model));
+            Assert.That(ex.Message, Is.EqualTo("Grade with ID: 1 not found."));
         }
 
         [Test]
@@ -523,7 +448,7 @@ namespace Tests.Admin
         }
 
         [Test]
-        public async Task GetGradeFormModelByIdAsync_ShouldThrowArgumentException_WhenGradeDoesNotExist()
+        public async Task GetGradeFormModelByIdAsync_ShouldThrowKeyNotFoundException_WhenGradeDoesNotExist()
         {
             // Arrange
             var gradeId = 1;
@@ -532,8 +457,8 @@ namespace Tests.Admin
                 .Returns(new List<Grade>().AsQueryable().BuildMock());
 
             // Act & Assert
-            var ex = Assert.ThrowsAsync<ArgumentException>(() => adminStudentService.GetGradeFormModelByIdAsync(gradeId));
-            Assert.That(ex.Message, Is.EqualTo("Grade not found."));
+            var ex = Assert.ThrowsAsync<KeyNotFoundException>(() => adminStudentService.GetGradeFormModelByIdAsync(gradeId));
+            Assert.That(ex.Message, Is.EqualTo("Grade with ID: 1 not found."));
         }
 
         [Test]
@@ -562,7 +487,7 @@ namespace Tests.Admin
         }
 
         [Test]
-        public async Task DeleteGradeAsync_ShouldThrowArgumentException_WhenGradeDoesNotExist()
+        public async Task DeleteGradeAsync_ShouldThrowKeyNotFoundException_WhenGradeDoesNotExist()
         {
             // Arrange
             var gradeId = 1;
@@ -571,8 +496,8 @@ namespace Tests.Admin
                 .Returns(new List<Grade>().AsQueryable().BuildMock());
 
             // Act & Assert
-            var ex = Assert.ThrowsAsync<ArgumentException>(() => adminStudentService.DeleteGradeAsync(gradeId));
-            Assert.That(ex.Message, Is.EqualTo("Grade not found."));
+            var ex = Assert.ThrowsAsync<KeyNotFoundException>(() => adminStudentService.DeleteGradeAsync(gradeId));
+            Assert.That(ex.Message, Is.EqualTo("Grade with ID: 1 not found."));
         }
 
         [Test]
@@ -580,39 +505,38 @@ namespace Tests.Admin
         {
             // Arrange
             var studentId = 1;
+            var students = new List<Student> { new Student { Id = studentId, IsDeleted = false } }
+                .AsQueryable().BuildMock();
+            repositoryMock.Setup(r => r.AllAsReadOnly<Student>()).Returns(students);
+
             var remarks = new List<Remark>
             {
-                new Remark { Id = 1, StudentId = studentId, CourseId = 1, RemarkText = "Great performance", IsDeleted = false, Course = new Course { Name = "Math" } },
-                new Remark { Id = 2, StudentId = studentId, CourseId = 2, RemarkText = "Needs improvement", IsDeleted = false, Course = new Course { Name = "Science" } }
-            };
-
-            repositoryMock.Setup(r => r.AllAsReadOnly<Remark>())
-                .Returns(remarks.AsQueryable().BuildMock());
+                new Remark { Id = 1, StudentId = studentId, CourseId = 1, RemarkText = "Great", IsDeleted = false, Course = new Course { Name = "Math" } },
+                new Remark { Id = 2, StudentId = studentId, CourseId = 2, RemarkText = "Ok", IsDeleted = false, Course = new Course { Name = "Science" } }
+            }.AsQueryable().BuildMock();
+            repositoryMock.Setup(r => r.AllAsReadOnly<Remark>()).Returns(remarks);
 
             // Act
-            var result = await adminStudentService.GetStudentRemarksAsync(studentId);
+            var result = (await adminStudentService.GetStudentRemarksAsync(studentId)).ToList();
 
             // Assert
             Assert.That(result, Is.Not.Null);
-            Assert.That(result.Count(), Is.EqualTo(2));
-            Assert.That(result.First().CourseName, Is.EqualTo("Math"));
-            Assert.That(result.Last().CourseName, Is.EqualTo("Science"));
+            Assert.That(result.Count, Is.EqualTo(2));
+            Assert.That(result[0].CourseName, Is.EqualTo("Math"));
+            Assert.That(result[1].CourseName, Is.EqualTo("Science"));
         }
 
         [Test]
-        public async Task GetStudentRemarksAsync_ShouldReturnEmpty_WhenNoRemarksExist()
+        public void GetStudentRemarksAsync_ThrowsKeyNotFoundException_WhenStudentDoesNotExist()
         {
             // Arrange
-            var studentId = 1;
+            var studentId = 999;
+            repositoryMock.Setup(r => r.AllAsReadOnly<Student>()).Returns(new List<Student>().AsQueryable().BuildMock());
+            // No need to setup remarks because existence check fails first.
 
-            repositoryMock.Setup(r => r.AllAsReadOnly<Remark>())
-                .Returns(new List<Remark>().AsQueryable().BuildMock());
-
-            // Act
-            var result = await adminStudentService.GetStudentRemarksAsync(studentId);
-
-            // Assert
-            Assert.That(result, Is.Empty);
+            // Act & Assert
+            var ex = Assert.ThrowsAsync<KeyNotFoundException>(() => adminStudentService.GetStudentRemarksAsync(studentId));
+            Assert.That(ex!.Message, Is.EqualTo($"Student with ID: {studentId} not found."));
         }
 
         [Test]
@@ -649,7 +573,7 @@ namespace Tests.Admin
         }
 
         [Test]
-        public async Task EditRemarkAsync_ShouldThrowArgumentException_WhenRemarkDoesNotExist()
+        public async Task EditRemarkAsync_ShouldThrowKeyNotFoundException_WhenRemarkDoesNotExist()
         {
             // Arrange
             var remarkId = 1;
@@ -663,8 +587,8 @@ namespace Tests.Admin
                 .Returns(new List<Remark>().AsQueryable().BuildMock());
 
             // Act & Assert
-            var ex = Assert.ThrowsAsync<ArgumentException>(() => adminStudentService.EditRemarkAsync(remarkId, model));
-            Assert.That(ex.Message, Is.EqualTo("Remark not found."));
+            var ex = Assert.ThrowsAsync<KeyNotFoundException>(() => adminStudentService.EditRemarkAsync(remarkId, model));
+            Assert.That(ex.Message, Is.EqualTo("Remark with ID: 1 not found."));
         }
         [Test]
         public async Task GetRemarkFormModelByIdAsync_ShouldReturnRemarkForm_WhenRemarkExists()
@@ -693,7 +617,7 @@ namespace Tests.Admin
         }
 
         [Test]
-        public async Task GetRemarkFormModelByIdAsync_ShouldThrowArgumentException_WhenRemarkDoesNotExist()
+        public async Task GetRemarkFormModelByIdAsync_ShouldThrowKeyNotFoundException_WhenRemarkDoesNotExist()
         {
             // Arrange
             var remarkId = 1;
@@ -702,48 +626,66 @@ namespace Tests.Admin
                 .Returns(new List<Remark>().AsQueryable().BuildMock());
 
             // Act & Assert
-            var ex = Assert.ThrowsAsync<ArgumentException>(() => adminStudentService.GetRemarkFormModelByIdAsync(remarkId));
-            Assert.That(ex.Message, Is.EqualTo("Remark not found."));
+            var ex = Assert.ThrowsAsync<KeyNotFoundException>(() => adminStudentService.GetRemarkFormModelByIdAsync(remarkId));
+            Assert.That(ex.Message, Is.EqualTo("Remark with ID: 1 not found."));
         }
 
         [Test]
-        public async Task GetStudentAbsencesAsync_ShouldReturnAbsences_WhenAbsencesExist()
+        public async Task GetStudentAbsencesAsync_ReturnsAbsences_WhenAbsencesExist()
         {
             // Arrange
             var studentId = 1;
-            var absences = new List<Absence>
-            {
-                new Absence { Id = 1, StudentId = studentId, CourseId = 1, Date = new DateTime(2024, 12, 1), IsDeleted = false, Course = new Course { Name = "Math" } },
-                new Absence { Id = 2, StudentId = studentId, CourseId = 2, Date = new DateTime(2024, 12, 2), IsDeleted = false, Course = new Course { Name = "Science" } }
-            };
+            var students = new List<Student> { new Student { Id = studentId, IsDeleted = false } }
+                .AsQueryable().BuildMock();
+            repositoryMock.Setup(r => r.AllAsReadOnly<Student>()).Returns(students);
 
-            repositoryMock.Setup(r => r.AllAsReadOnly<Absence>())
-                .Returns(absences.AsQueryable().BuildMock());
+            var absencesList = new List<Absence>
+            {
+                new Absence { Id = 1, StudentId = studentId, Course = new Course { Name = "Math" }, Date = new DateTime(2024,12,1), IsDeleted = false },
+                new Absence { Id = 2, StudentId = studentId, Course = new Course { Name = "Science" }, Date = new DateTime(2024,12,2), IsDeleted = false }
+            }.AsQueryable().BuildMock();
+            repositoryMock.Setup(r => r.AllAsReadOnly<Absence>()).Returns(absencesList);
 
             // Act
-            var result = await adminStudentService.GetStudentAbsencesAsync(studentId);
+            var result = (await adminStudentService.GetStudentAbsencesAsync(studentId)).ToList();
 
             // Assert
             Assert.That(result, Is.Not.Null);
-            Assert.That(result.Count(), Is.EqualTo(2));
-            Assert.That(result.First().CourseName, Is.EqualTo("Math"));
-            Assert.That(result.Last().CourseName, Is.EqualTo("Science"));
+            Assert.That(result.Count, Is.EqualTo(2));
+            Assert.That(result[0].CourseName, Is.EqualTo("Math"));
+            Assert.That(result[1].CourseName, Is.EqualTo("Science"));
         }
 
         [Test]
-        public async Task GetStudentAbsencesAsync_ShouldReturnEmpty_WhenNoAbsencesExist()
+        public async Task GetStudentAbsencesAsync_ReturnsEmpty_WhenNoAbsencesExist()
         {
             // Arrange
             var studentId = 1;
+            var students = new List<Student> { new Student { Id = studentId, IsDeleted = false } }
+                .AsQueryable().BuildMock();
+            repositoryMock.Setup(r => r.AllAsReadOnly<Student>()).Returns(students);
 
-            repositoryMock.Setup(r => r.AllAsReadOnly<Absence>())
-                .Returns(new List<Absence>().AsQueryable().BuildMock());
+            var emptyAbsences = new List<Absence>().AsQueryable().BuildMock();
+            repositoryMock.Setup(r => r.AllAsReadOnly<Absence>()).Returns(emptyAbsences);
 
             // Act
             var result = await adminStudentService.GetStudentAbsencesAsync(studentId);
 
             // Assert
             Assert.That(result, Is.Empty);
+        }
+
+        [Test]
+        public void GetStudentAbsencesAsync_ThrowsKeyNotFoundException_WhenStudentDoesNotExist()
+        {
+            // Arrange
+            var studentId = 999;
+            repositoryMock.Setup(r => r.AllAsReadOnly<Student>()).Returns(new List<Student>().AsQueryable().BuildMock());
+            // Absences setup not required because existence check fails first.
+
+            // Act & Assert
+            var ex = Assert.ThrowsAsync<KeyNotFoundException>(() => adminStudentService.GetStudentAbsencesAsync(studentId));
+            Assert.That(ex!.Message, Is.EqualTo($"Student with ID: {studentId} not found."));
         }
 
         [Test]
@@ -773,7 +715,7 @@ namespace Tests.Admin
         }
 
         [Test]
-        public async Task GetAbsenceFormModelByIdAsync_ShouldThrowArgumentException_WhenAbsenceDoesNotExist()
+        public async Task GetAbsenceFormModelByIdAsync_ShouldThrowKeyNotFoundException_WhenAbsenceDoesNotExist()
         {
             // Arrange
             var absenceId = 1;
@@ -782,8 +724,8 @@ namespace Tests.Admin
                 .Returns(new List<Absence>().AsQueryable().BuildMock());
 
             // Act & Assert
-            var ex = Assert.ThrowsAsync<ArgumentException>(() => adminStudentService.GetAbsenceFormModelByIdAsync(absenceId));
-            Assert.That(ex.Message, Is.EqualTo("Absence not found."));
+            var ex = Assert.ThrowsAsync<KeyNotFoundException>(() => adminStudentService.GetAbsenceFormModelByIdAsync(absenceId));
+            Assert.That(ex.Message, Is.EqualTo("Absence with ID: 1 not found."));
         }
 
         [Test]
@@ -820,7 +762,7 @@ namespace Tests.Admin
         }
 
         [Test]
-        public async Task EditAbsenceAsync_ShouldThrowArgumentException_WhenAbsenceDoesNotExist()
+        public async Task EditAbsenceAsync_ShouldThrowKeyNotFoundException_WhenAbsenceDoesNotExist()
         {
             // Arrange
             var absenceId = 1;
@@ -834,8 +776,8 @@ namespace Tests.Admin
                 .Returns(new List<Absence>().AsQueryable().BuildMock());
 
             // Act & Assert
-            var ex = Assert.ThrowsAsync<ArgumentException>(() => adminStudentService.EditAbsenceAsync(absenceId, model));
-            Assert.That(ex.Message, Is.EqualTo("Absence not found."));
+            var ex = Assert.ThrowsAsync<KeyNotFoundException>(() => adminStudentService.EditAbsenceAsync(absenceId, model));
+            Assert.That(ex.Message, Is.EqualTo("Absence with ID: 1 not found."));
         }
 
         [Test]
@@ -863,7 +805,7 @@ namespace Tests.Admin
         }
 
         [Test]
-        public async Task DeleteAbsenceAsync_ShouldThrowArgumentException_WhenAbsenceDoesNotExist()
+        public async Task DeleteAbsenceAsync_ShouldThrowException_WhenAbsenceDoesNotExist()
         {
             // Arrange
             var absenceId = 1;
@@ -872,8 +814,8 @@ namespace Tests.Admin
                 .Returns(new List<Absence>().AsQueryable().BuildMock());
 
             // Act & Assert
-            var ex = Assert.ThrowsAsync<ArgumentException>(() => adminStudentService.DeleteAbsenceAsync(absenceId));
-            Assert.That(ex.Message, Is.EqualTo("Absence not found."));
+            var ex = Assert.ThrowsAsync<KeyNotFoundException>(() => adminStudentService.DeleteAbsenceAsync(absenceId));
+            Assert.That(ex.Message, Is.EqualTo("Absence with ID: 1 not found."));
         }
 
 

--- a/StudentServiceTests/Admin/AdminTeacherServiceTests.cs
+++ b/StudentServiceTests/Admin/AdminTeacherServiceTests.cs
@@ -1,7 +1,9 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Logging;
 using MockQueryable;
 using Moq;
+using StudentManagementSystem.Areas.Admin.Controllers;
 using StudentManagementSystem.Core.Models.Admin.Teacher;
 using StudentManagementSystem.Core.Services.Admin;
 using StudentManagementSystem.Infrastructure.Data.Common;
@@ -14,12 +16,14 @@ namespace Tests.Admin
     {
         private Mock<IRepository> mockRepository;
         private AdminTeacherService adminTeacherService;
+        private Mock<ILogger<AdminTeacherService>> mockLogger;
 
         [SetUp]
         public void Setup()
         {
             mockRepository = new Mock<IRepository>();
-            adminTeacherService = new AdminTeacherService(mockRepository.Object);
+            mockLogger = new Mock<ILogger<AdminTeacherService>>();
+            adminTeacherService = new AdminTeacherService(mockRepository.Object, mockLogger.Object);
         }
 
         [Test]
@@ -313,7 +317,7 @@ namespace Tests.Admin
                 .Returns(new List<Teacher>().AsQueryable().BuildMock());
 
              
-            await Task.Run(() => Assert.ThrowsAsync<ArgumentException>(async () => await adminTeacherService.GetTeacherDetailsModelByIdAsync(teacherId)));
+            await Task.Run(() => Assert.ThrowsAsync<KeyNotFoundException>(async () => await adminTeacherService.GetTeacherDetailsModelByIdAsync(teacherId)));
         }
 
         [Test]

--- a/StudentServiceTests/Admin/AdminUserManageControllerTests.cs
+++ b/StudentServiceTests/Admin/AdminUserManageControllerTests.cs
@@ -1,7 +1,10 @@
-﻿    using Microsoft.AspNetCore.Identity;
+﻿using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 using Moq;
 using StudentManagementSystem.Areas.Admin.Controllers;
+using StudentManagementSystem.Core.Services.Admin;
 using StudentManagementSystem.Models;
 
 namespace Tests.Admin
@@ -12,6 +15,7 @@ namespace Tests.Admin
         private Mock<RoleManager<IdentityRole<string>>> roleManagerMock;
         private Mock<UserManager<IdentityUser>> userManagerMock;
         private AdminUserManageController controller;
+        private Mock<ILogger<AdminUserManageController>> mockLogger;
 
         [SetUp]
         public void SetUp()
@@ -22,7 +26,8 @@ namespace Tests.Admin
             var userStore = new Mock<IUserStore<IdentityUser>>();
             userManagerMock = new Mock<UserManager<IdentityUser>>(userStore.Object, null, null, null, null, null, null, null, null);
 
-            controller = new AdminUserManageController(roleManagerMock.Object, userManagerMock.Object);
+            mockLogger = new Mock<ILogger<AdminUserManageController>>();
+            controller = new AdminUserManageController(roleManagerMock.Object, userManagerMock.Object, mockLogger.Object);
         }
 
         [TearDown]
@@ -118,7 +123,7 @@ namespace Tests.Admin
             var result = await controller.DeleteRole(roleName);
 
             
-            Assert.IsInstanceOf<BadRequestResult>(result);
+            Assert.IsInstanceOf<NotFoundResult>(result);
         }
 
         [Test]

--- a/StudentServiceTests/StudentServiceTests.cs
+++ b/StudentServiceTests/StudentServiceTests.cs
@@ -1,6 +1,7 @@
 ﻿using MockQueryable;
 using MockQueryable.Moq;
 using Moq;
+using NUnit.Framework;
 using StudentManagementSystem.Core.Services;
 using StudentManagementSystem.Infrastructure.Data.Common;
 using StudentManagementSystem.Infrastructure.Data.Models;
@@ -72,6 +73,9 @@ namespace Tests
             var mockAbsences = absences.AsQueryable().BuildMock();
             mockRepository.Setup(r => r.AllAsReadOnly<Absence>()).Returns(mockAbsences);
 
+            var students = new List<Student> { new Student { Id = studentId, IsDeleted = false } }.AsQueryable().BuildMock();
+            mockRepository.Setup(r => r.AllAsReadOnly<Student>()).Returns(students);
+
             
             var result = await studentService.GetAllAbsencesAsync(studentId);
 
@@ -97,7 +101,9 @@ namespace Tests
             var mockRemarks = remarks.AsQueryable().BuildMock();
             mockRepository.Setup(r => r.AllAsReadOnly<Remark>()).Returns(mockRemarks);
 
-            
+            var students = new List<Student> { new Student { Id = studentId, IsDeleted = false } }.AsQueryable().BuildMock();
+            mockRepository.Setup(r => r.AllAsReadOnly<Student>()).Returns(students);
+
             var result = await studentService.GetAllRemarksAsync(studentId);
 
             
@@ -228,18 +234,15 @@ namespace Tests
         }
 
         [Test]
-        public async Task GetStudentIdAsync_ShouldReturnZero_WhenUserIdDoesNotExist()
+        public async Task GetStudentIdAsync_ShouldReturnException_WhenUserIdDoesNotExist()
         {
             
             var userId = "user123";
             var mockStudents = new List<Student>().AsQueryable().BuildMock();
             mockRepository.Setup(r => r.AllAsReadOnly<Student>()).Returns(mockStudents);
 
-            
-            var result = await studentService.GetStudentIdAsync(userId);
-
-            
-            Assert.AreEqual(0, result);
+            var ex = Assert.ThrowsAsync<KeyNotFoundException>(async () => await studentService.GetStudentIdAsync(userId));
+            Assert.That(ex.Message, Is.EqualTo($"Student id for user '{userId}' was not found."));
         }
     }
 }

--- a/StudentServiceTests/TeacherServiceTests.cs
+++ b/StudentServiceTests/TeacherServiceTests.cs
@@ -74,7 +74,7 @@ namespace Tests
         }
 
         [Test]
-        public void AddGradeToStudent_ShouldThrowArgumentNullException_WhenStudentIsNotFound()
+        public void AddGradeToStudent_ShouldThrowKeyNotFoundException_WhenStudentIsNotFound()
         {
             
             var studentId = 1;
@@ -88,12 +88,12 @@ namespace Tests
             mockRepository.Setup(r => r.All<Student>())
                 .Returns(Enumerable.Empty<Student>().AsQueryable().BuildMock());  // No student found
 
-            Assert.That(() => teacherService.AddGradeToStudent(model, studentId),
-                Throws.ArgumentNullException.With.Message.Contains("Student not found"));
+            var ex = Assert.ThrowsAsync<KeyNotFoundException>(async () => await teacherService.AddGradeToStudent(model, studentId));
+            Assert.That(ex.Message, Does.Contain("Student").And.Contain("not found"));
         }
 
         [Test]
-        public void AddGradeToStudent_ShouldThrowArgumentNullException_WhenCourseIsNotFound()
+        public void AddGradeToStudent_ShouldThrowKeyNotFoundException_WhenCourseIsNotFound()
         {
             
             var studentId = 1;
@@ -117,9 +117,8 @@ namespace Tests
             mockRepository.Setup(r => r.All<Course>())
                 .Returns(Enumerable.Empty<Course>().AsQueryable().BuildMock());  // No course found
 
-            
-            Assert.That(() => teacherService.AddGradeToStudent(model, studentId),
-                Throws.ArgumentNullException.With.Message.Contains("Course not found"));
+            var ex = Assert.ThrowsAsync<KeyNotFoundException>(async () => await teacherService.AddGradeToStudent(model, studentId));
+            Assert.That(ex.Message, Does.Contain("Course").And.Contain("not found"));
         }
         [Test]
         public async Task AddRemarkToStudentAsync_ShouldReturnRemarkId_WhenValidDataIsProvided()
@@ -169,7 +168,7 @@ namespace Tests
             Assert.That(result, Is.GreaterThan(0)); // Expecting a valid Remark ID to be returned
         }
         [Test]
-        public void AddRemarkToStudentAsync_ShouldThrowArgumentNullException_WhenStudentNotFound()
+        public void AddRemarkToStudentAsync_ShouldThrowKeyNotFoundException_WhenStudentNotFound()
         {
             
             var studentId = 1;
@@ -183,12 +182,11 @@ namespace Tests
             mockRepository.Setup(r => r.All<Student>())
                 .Returns(Enumerable.Empty<Student>().AsQueryable().BuildMock());  // No student found
 
-            
-            Assert.That(() => teacherService.AddRemarkToStudentAsync(model, studentId),
-                Throws.ArgumentNullException.With.Message.Contains("Student not found"));
+            var ex = Assert.ThrowsAsync<KeyNotFoundException>(async () => await teacherService.AddRemarkToStudentAsync(model, studentId));
+            Assert.That(ex.Message, Does.Contain("Student").And.Contain("not found"));
         }
         [Test]
-        public void AddRemarkToStudentAsync_ShouldThrowArgumentNullException_WhenCourseNotFound()
+        public void AddRemarkToStudentAsync_ShouldThrowKeyNotFoundException_WhenCourseNotFound()
         {
             
             var studentId = 1;
@@ -212,9 +210,8 @@ namespace Tests
             mockRepository.Setup(r => r.All<Course>())
                 .Returns(Enumerable.Empty<Course>().AsQueryable().BuildMock());  // No course found
 
-            
-            Assert.That(() => teacherService.AddRemarkToStudentAsync(model, studentId),
-                Throws.ArgumentNullException.With.Message.Contains("Course not found"));
+            var ex = Assert.ThrowsAsync<KeyNotFoundException>(async () => await teacherService.AddRemarkToStudentAsync(model, studentId));
+            Assert.That(ex.Message, Does.Contain("Course").And.Contain("not found"));
         }
         [Test]
         public async Task GetTeacherEntityIdByUserIdAsync_ShouldReturnTeacherId_WhenTeacherExists()
@@ -239,7 +236,7 @@ namespace Tests
         }
 
         [Test]
-        public void GetTeacherEntityIdByUserIdAsync_ShouldThrowArgumentNullException_WhenTeacherNotFound()
+        public void GetTeacherEntityIdByUserIdAsync_ShouldThrowKeyNotFoundException_WhenTeacherNotFound()
         {
             
             var userId = "nonexistentTeacher";
@@ -247,9 +244,8 @@ namespace Tests
             mockRepository.Setup(r => r.AllAsReadOnly<Teacher>())
                 .Returns(Enumerable.Empty<Teacher>().AsQueryable().BuildMock());  // No teacher found
 
-            
-            Assert.That(() => teacherService.GetTeacherEntityIdByUserIdAsync(userId),
-                Throws.ArgumentNullException.With.Message.Contains("Teacher not found"));
+            var ex = Assert.ThrowsAsync<KeyNotFoundException>(async () => await teacherService.GetTeacherEntityIdByUserIdAsync(userId));
+            Assert.That(ex.Message, Does.Contain("Teacher").And.Contain("not found"));
         }
 
         [Test]
@@ -310,7 +306,7 @@ namespace Tests
         }
 
         [Test]
-        public void RemarkOfStudentExists_ShouldThrowArgumentNullException_WhenStudentNotFound()
+        public void RemarkOfStudentExists_ShouldThrowKeyNotFoundException_WhenStudentNotFound()
         {
             
             var studentId = 1;
@@ -320,9 +316,8 @@ namespace Tests
             mockRepository.Setup(r => r.All<Student>())
                 .Returns(Enumerable.Empty<Student>().AsQueryable().BuildMock());  // No student found
 
-            
-            Assert.That(() => teacherService.RemarkOfStudentExists(studentId, remarkText, courseId),
-                Throws.ArgumentNullException.With.Message.Contains("Student not found"));
+            var ex = Assert.ThrowsAsync<KeyNotFoundException>(async () => await teacherService.RemarkOfStudentExists(studentId, remarkText, courseId));
+            Assert.That(ex.Message, Does.Contain("Student").And.Contain("not found"));
         }
 
         [Test]
@@ -350,7 +345,7 @@ namespace Tests
         }
 
         [Test]
-        public void GetCourseNameById_ShouldThrowArgumentNullException_WhenCourseNotFound()
+        public void GetCourseNameById_ShouldThrowKeyNotFoundException_WhenCourseNotFound()
         {
             
             var courseId = 1;
@@ -358,9 +353,8 @@ namespace Tests
             mockRepository.Setup(r => r.AllAsReadOnly<Course>())
                 .Returns(Enumerable.Empty<Course>().AsQueryable().BuildMock());  // No course found
 
-            
-            Assert.That(() => teacherService.GetCourseNameById(courseId),
-                Throws.ArgumentNullException.With.Message.Contains("Course not found"));
+            var ex = Assert.ThrowsAsync<KeyNotFoundException>(async () => await teacherService.GetCourseNameById(courseId));
+            Assert.That(ex.Message, Does.Contain("Course").And.Contain("not found"));
         }
 
         [Test]
@@ -398,7 +392,7 @@ namespace Tests
         }
 
         [Test]
-        public void GetGradeByIdAsync_ShouldThrowArgumentNullException_WhenGradeNotFound()
+        public void GetGradeByIdAsync_ShouldThrowKeyNotFoundException_WhenGradeNotFound()
         {
             
             var gradeId = 1;
@@ -406,9 +400,8 @@ namespace Tests
             mockRepository.Setup(r => r.AllAsReadOnly<Grade>())
                 .Returns(Enumerable.Empty<Grade>().AsQueryable().BuildMock());  // No grade found
 
-            
-            Assert.That(() => teacherService.GetGradeByIdAsync(gradeId),
-                Throws.ArgumentNullException.With.Message.Contains("Grade not found"));
+            var ex = Assert.ThrowsAsync<KeyNotFoundException>(async () => await teacherService.GetGradeByIdAsync(gradeId));
+            Assert.That(ex.Message, Does.Contain("Grade").And.Contain("not found"));
         }
 
         [Test]
@@ -448,7 +441,7 @@ namespace Tests
         }
 
         [Test]
-        public void EditGradeAsync_ShouldThrowArgumentNullException_WhenGradeNotFound()
+        public void EditGradeAsync_ShouldThrowKeyNotFoundException_WhenGradeNotFound()
         {
             
             var gradeId = 1;
@@ -462,9 +455,8 @@ namespace Tests
             mockRepository.Setup(r => r.All<Grade>())
                 .Returns(Enumerable.Empty<Grade>().AsQueryable().BuildMock());  // No grade found
 
-            
-            Assert.That(() => teacherService.EditGradeAsync(gradeId, gradeModel),
-                Throws.ArgumentNullException.With.Message.Contains("Grade not found"));
+            var ex = Assert.ThrowsAsync<KeyNotFoundException>(async () => await teacherService.EditGradeAsync(gradeId, gradeModel));
+            Assert.That(ex.Message, Does.Contain("Grade").And.Contain("not found"));
         }
 
         [Test]
@@ -496,7 +488,7 @@ namespace Tests
         }
 
         [Test]
-        public void DeleteGradeAsync_ShouldThrowArgumentNullException_WhenGradeNotFound()
+        public void DeleteGradeAsync_ShouldThrowKeyNotFoundException_WhenGradeNotFound()
         {
             
             var gradeId = 1;
@@ -504,9 +496,8 @@ namespace Tests
             mockRepository.Setup(r => r.All<Grade>())
                 .Returns(Enumerable.Empty<Grade>().AsQueryable().BuildMock());  // No grade found
 
-            
-            Assert.That(() => teacherService.DeleteGradeAsync(gradeId),
-                Throws.ArgumentNullException.With.Message.Contains("Grade not found"));
+            var ex = Assert.ThrowsAsync<KeyNotFoundException>(async () => await teacherService.DeleteGradeAsync(gradeId));
+            Assert.That(ex.Message, Does.Contain("Grade").And.Contain("not found"));
         }
 
         [Test]
@@ -515,20 +506,19 @@ namespace Tests
             
             var absenceId = 1;
             var absences = new List<Absence>
-        {
-            new Absence
             {
-                Id = absenceId,
-                StudentId = 100,
-                CourseId = 200,
-                Date = new DateTime(2024, 12, 15),
-                IsDeleted = false
-            }
-        }.AsQueryable().BuildMock();
+                new Absence
+                {
+                    Id = absenceId,
+                    StudentId = 100,
+                    CourseId = 200,
+                    Date = new DateTime(2024, 12, 15),
+                    IsDeleted = false
+                }
+            }.AsQueryable().BuildMock();
 
-            mockRepository.Setup(r => r.All<Absence>()).Returns(absences);
+            mockRepository.Setup(r => r.AllAsReadOnly<Absence>()).Returns(absences);
 
-           
             var result = await teacherService.GetAbsenceByIdAsync(absenceId);
 
             
@@ -541,17 +531,16 @@ namespace Tests
 
 
         [Test]
-        public void GetAbsenceByIdAsync_ShouldThrowArgumentNullException_WhenAbsenceNotFound()
+        public void GetAbsenceByIdAsync_ShouldThrowKeyNotFoundException_WhenAbsenceNotFound()
         {
             
             var absenceId = 1;
 
-            mockRepository.Setup(r => r.All<Absence>())
+            mockRepository.Setup(r => r.AllAsReadOnly<Absence>())
                 .Returns(Enumerable.Empty<Absence>().AsQueryable().BuildMock());  // No absence found
 
-            
-            Assert.That(() => teacherService.GetAbsenceByIdAsync(absenceId),
-                Throws.ArgumentNullException.With.Message.Contains("Absence not found"));
+            var ex = Assert.ThrowsAsync<KeyNotFoundException>(async () => await teacherService.GetAbsenceByIdAsync(absenceId));
+            Assert.That(ex.Message, Does.Contain("Absence").And.Contain("not found"));
         }
 
         [Test]
@@ -604,8 +593,7 @@ namespace Tests
             var remarkId = 1;
             var remark = new Remark { Id = remarkId, IsDeleted = false };
 
-            mockRepository.Setup(r => r.All<Remark>())
-                .Returns(new List<Remark> { remark }.AsQueryable().BuildMock());
+            mockRepository.Setup(r => r.All<Remark>()).Returns(new List<Remark> { remark }.AsQueryable().BuildMock());
 
            
             var result = await teacherService.GetRemarkByIdAsync(remarkId);
@@ -627,8 +615,7 @@ namespace Tests
             };
             var remark = new Remark { Id = remarkId, IsDeleted = false };
 
-            mockRepository.Setup(r => r.All<Remark>())
-                .Returns(new List<Remark> { remark }.AsQueryable().BuildMock());
+            mockRepository.Setup(r => r.All<Remark>()).Returns(new List<Remark> { remark }.AsQueryable().BuildMock());
 
            
             var result = await teacherService.EditRemarkASync(remarkId, model);
@@ -647,8 +634,7 @@ namespace Tests
             var remarkId = 1;
             var remark = new Remark { Id = remarkId, IsDeleted = false };
 
-            mockRepository.Setup(r => r.All<Remark>())
-                .Returns(new List<Remark> { remark }.AsQueryable().BuildMock());
+            mockRepository.Setup(r => r.All<Remark>()).Returns(new List<Remark> { remark }.AsQueryable().BuildMock());
 
            
             await teacherService.DeleteRemarkAsync(remarkId);
@@ -672,7 +658,10 @@ namespace Tests
             mockRepository.Setup(r => r.AddAsync(It.IsAny<News>())).Returns(Task.CompletedTask);
             mockRepository.Setup(r => r.SaveChangesAsync()).Returns(Task.FromResult(1));
 
-           
+            var teacher = new Teacher { Id = 1, UserId = "teacher1" };
+            mockRepository.Setup(r => r.AllAsReadOnly<Teacher>())
+                .Returns(new List<Teacher> { teacher }.AsQueryable().BuildMock());
+
             var result = await teacherService.AddNewsToTeacherAsync(model);
 
             
@@ -767,7 +756,7 @@ namespace Tests
         }
 
         [Test]
-        public void GetStudentsByMainClassTeacherAsync_ShouldThrowException_WhenNoStudentsFound()
+        public void GetStudentsByMainClassTeacherAsync_ShouldThrowKeyNotFoundException_WhenNoStudentsFound()
         {
             
             var userId = "testUserId";
@@ -777,8 +766,7 @@ namespace Tests
             mockRepository.Setup(r => r.All<Student>()).Returns(students);
             mockRepository.Setup(r => r.AllAsReadOnly<Teacher>()).Returns(new List<Teacher> { new Teacher { Id = teacherId, UserId = userId } }.AsQueryable().BuildMock());
 
-            
-            Assert.ThrowsAsync<ArgumentNullException>(async () => await teacherService.GetStudentsByMainClassTeacherAsync(userId));
+            Assert.ThrowsAsync<KeyNotFoundException>(async () => await teacherService.GetStudentsByMainClassTeacherAsync(userId));
         }
 
         [Test]
@@ -815,7 +803,7 @@ namespace Tests
         }
 
         [Test]
-        public void GetMainTeacherStudentDetailsAsync_ShouldThrowException_WhenStudentNotFound()
+        public void GetMainTeacherStudentDetailsAsync_ShouldThrowKeyNotFoundException_WhenStudentNotFound()
         {
             
             var studentId = 1;
@@ -823,8 +811,7 @@ namespace Tests
 
             mockRepository.Setup(r => r.AllAsReadOnly<Student>()).Returns(students);
 
-            
-            Assert.ThrowsAsync<ArgumentNullException>(async () => await teacherService.GetMainTeacherStudentDetailsAsync(studentId));
+            Assert.ThrowsAsync<KeyNotFoundException>(async () => await teacherService.GetMainTeacherStudentDetailsAsync(studentId));
         }
 
         [Test]
@@ -907,7 +894,7 @@ namespace Tests
         }
 
         [Test]
-        public void GetAllClassesByTeacher_ShouldThrowArgumentNullException_WhenTeacherNotFound()
+        public void GetAllClassesByTeacher_ShouldThrowKeyNotFoundException_WhenTeacherNotFound()
         {
             
             var userId = "invalidTeacher";
@@ -915,9 +902,8 @@ namespace Tests
 
             mockRepository.Setup(r => r.AllAsReadOnly<Teacher>()).Returns(teachersMock);
 
-            
             Assert.That(async () => await teacherService.GetAllClassesByTeacher(userId),
-                Throws.TypeOf<ArgumentNullException>());
+                Throws.TypeOf<KeyNotFoundException>());
         }
 
         [Test]

--- a/render.yaml
+++ b/render.yaml
@@ -5,7 +5,7 @@ services:
     env: docker
     plan: free
     region: frankfurt
-    branch: master
+    branch: render-deployment
     dockerfilePath: ./Dockerfile
     envVars:
       - key: DATABASE_URL


### PR DESCRIPTION
This pull request focuses on improving error handling consistency across the codebase by standardizing the use of `KeyNotFoundException` for not-found scenarios, updating related unit tests, and making minor improvements to date handling and repository usage. The changes increase clarity, reliability, and maintainability of both the application code and the test suite.

**Error handling standardization:**

* Replaced `ArgumentException` with `KeyNotFoundException` for entities not found in service methods such as editing or retrieving remarks, courses, students, and course schedules (`AdminStudentService.cs`, `AdminCourseServiceTests.cs`, `AdminScheduleServiceTests.cs`, `AdminStudentServiceTests.cs`). 

* Updated unit tests to expect `KeyNotFoundException` instead of `ArgumentException` or generic exceptions, and adjusted test names and assertions accordingly throughout the test files. 
**Repository and data handling improvements:**

* Ensured that repository mocks for `AllAsReadOnly` return correctly configured async queryables in unit tests, improving test reliability for EF Core async extensions (`AdminClassServiceTests.cs`, `AdminCourseServiceTests.cs`, `AdminScheduleServiceTests.cs`). 

* Changed repository usage in absence retrieval to use `AllAsReadOnly` for consistency and potentially improved performance (`TeacherService.cs`).

**Date handling consistency:**

* Removed unnecessary `.Date` property access when specifying `DateTimeKind.Utc` for absence dates, ensuring the full date and time are preserved (`TeacherService.cs`). 
**Test suite cleanup:**

* Removed redundant or obsolete test cases, such as those checking for no-ops on already deleted entities or not found scenarios now covered by exception handling (`AdminCourseServiceTests.cs`, `AdminScheduleServiceTests.cs`, `AdminStudentServiceTests.cs`).
**Miscellaneous:**

* Minor code cleanup and organization in test files, including import adjustments and whitespace fixes (`AdminCourseServiceTests.cs`, `AdminStudentServiceTests.cs`). 